### PR TITLE
Add support to string parameter with white space

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -31,6 +31,7 @@ __all__ = ['MacroButton']
 
 import functools
 import shlex
+import re
 
 import PyTango
 
@@ -217,6 +218,8 @@ class MacroButton(TaurusWidget):
         while len(self.macro_args) < index + 1:
             self.macro_args.append('')
         #update the given argument
+        if re.search('\s', value):
+            value = '"{0}"'.format(value)
         self.macro_args[index] = str(value)
         #update tooltip
         self.setToolTip(self.macro_name + ' ' + ' '.join(self.macro_args))


### PR DESCRIPTION
Macrobutton incorrectly splits arguments with white characters
on it.

Fix: update such string parameters by adding extra double quotes
in the updateMacroArgument method.